### PR TITLE
added code for displaying virtual environment

### DIFF
--- a/configs/.zshrc
+++ b/configs/.zshrc
@@ -94,3 +94,12 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+
+# Add virtual environment display to the prompt
+# this will add display when user activate their virtual environment
+# it help people know which env they are in
+autoload -U add-zsh-hook
+venv_info() {
+    [ -n "$VIRTUAL_ENV" ] && echo "(Virtual Environment: $(basename $VIRTUAL_ENV))"
+}
+add-zsh-hook precmd venv_info


### PR DESCRIPTION
**The problem** 
I encountered a problem where activating my Python virtual environment didn't reflect in the shell prompt. There was no indication that the virtual environment was active. This code addresses the issue by displaying the name of the virtual environment above the shell prompt when it's activated.

**Solution:**
The provided Zsh code resolves the issue by defining a function, venv_info(), which checks if a virtual environment is active ($VIRTUAL_ENV is set). If a virtual environment is active, it echoes a message above the prompt, indicating the name of the virtual environment. This information is displayed each time the precmd hook is triggered, just before the prompt is shown.

This modification improves the user experience by providing a clear visual indication of the active virtual environment, making it easier for the user to identify their working context.